### PR TITLE
Fix leaking file descriptors by using the context manager

### DIFF
--- a/gerapy_playwright/utils.py
+++ b/gerapy_playwright/utils.py
@@ -49,5 +49,5 @@ async def is_playwright_installed():
     """
     check if playwright is installed
     """
-    playwright = await async_playwright().start()
-    return exists(playwright.chromium.executable_path)
+    async with async_playwright() as playwright:
+        return exists(playwright.chromium.executable_path)


### PR DESCRIPTION
I was running into `OSError: [Errno 24] Too many open files` while using this with scrapy for scraping a domain.

By using `async_playwright()` as a context manager, we ensure it's closed once finished. This fixes the issue.